### PR TITLE
Change mode_switch to ISO_Level5_Shift to fix broken cursors layer on Wayland

### DIFF
--- a/linux/xkb/symbols/3l
+++ b/linux/xkb/symbols/3l
@@ -4,128 +4,104 @@ xkb_symbols "basic" {
 
     // Alphanumeric-keys
     // ===============
-    key.type[Group1] = "FOUR_LEVEL";
-    key.type[Group2] = "TWO_LEVEL";
+    key.type[Group1] = "ONE_LEVEL";
 
     // Tab as Escape
     // --------------------------------------------------------------
     key  <TAB> {
-        [ Escape,               Escape,               Escape,               Escape         ],
-        [ Escape,               Escape                  ]
+        //[ Escape,                  Escape,                  Escape,                  Escape,                Escape,                Escape               ]
+        [ Escape ]
     };
 
 
     // Number row
     // --------------------------------------------------------------
     key <TLDE> {
-        [ NoSymbol,                 NoSymbol,               NoSymbol,                NoSymbol                ],
-        [ NoSymbol,                 NoSymbol                 ]
+        //[ NoSymbol,                NoSymbol,                NoSymbol,                NoSymbol,              NoSymbol,              NoSymbol              ]
+        [ NoSymbol ]
     };
 
+    key.type[Group1] = "FOUR_LEVEL";
+
     key <AE01> {
-        [ 1,                       degree,                  onesuperior,             onesubscript            ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ 1,                       degree,                  onesuperior,             onesubscript,          NoSymbol,              NoSymbol              ]
     };
     key <AE02> {
-        [ 2,                       section,                 twosuperior,             twosubscript            ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ 2,                       section,                 twosuperior,             twosubscript,          NoSymbol,              NoSymbol              ]
     };
     key <AE03> {
-        [ 3,                       U2113,                   threesuperior,           threesubscript          ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ 3,                       U2113,                   threesuperior,           threesubscript,        NoSymbol,              NoSymbol              ]
     };
     key <AE04> {
-        [ 4,                       guillemotright,          U203A,                   femalesymbol            ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ 4,                       guillemotright,          U203A,                   femalesymbol,          NoSymbol,              NoSymbol              ]
     };
     key <AE05> {
-        [ 5,                       guillemotleft,           U2039,                   malesymbol              ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ 5,                       guillemotleft,           U2039,                   malesymbol,            NoSymbol,              NoSymbol              ]
     };
     key <AE06> {
-        [ 6,                       dollar,                  cent,                    U26A5                   ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ 6,                       dollar,                  cent,                    U26A5,                 NoSymbol,              NoSymbol              ]
     };
 
     key <AE07> {
-        [ 7,                       EuroSign,                yen,                     U03F0                   ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ 7,                       EuroSign,                yen,                     U03F0,                 NoSymbol,              NoSymbol              ]
     };
     key <AE08> {
-        [ 8,                       doublelowquotemark,      singlelowquotemark,      U27E8                   ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ 8,                       doublelowquotemark,      singlelowquotemark,      U27E8,                 NoSymbol,              NoSymbol              ]
     };
     key <AE09> {
-        [ 9,                       leftdoublequotemark,     leftsinglequotemark,     U27E9                   ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ 9,                       leftdoublequotemark,     leftsinglequotemark,     U27E9,                 NoSymbol,              NoSymbol              ]
     };
     key <AE10> {
-        [ 0,                       rightdoublequotemark,    rightsinglequotemark,    zerosubscript           ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ 0,                       rightdoublequotemark,    rightsinglequotemark,    zerosubscript,         NoSymbol,              NoSymbol              ]
     };
 
     key <AE11> {
-        [ equal,                   less,                    NoSymbol,                U2011                   ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ equal,                   less,                    NoSymbol,                U2011,                 NoSymbol,              NoSymbol              ]
     };
     key <AE12> {
-        [ underscore,              greater,                 dead_abovering,          dead_dasia              ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ underscore,              greater,                 dead_abovering,          dead_dasia,            NoSymbol,              NoSymbol              ]
     };
 
     // Top row
     // --------------------------------------------------------------
-    key.type[Group1] = "FOUR_LEVEL_SEMIALPHABETIC";
-    key <AD01> {
-        [ q,                       Q,                       quotedbl,                Greek_xi                ],
-        [ Prior,                   NoSymbol                  ]
+    key.type[Group1] = "EIGHT_LEVEL_SEMIALPHABETIC";
+    key <AD01> { 
+        [ q,                       Q,                       quotedbl,                Greek_xi,              Prior,                   NoSymbol            ]
     };
     key <AD02> {
-        [ f,                       F,                       underscore,              NoSymbol                ],
-        [ BackSpace,               NoSymbol                  ]
+        [ f,                       F,                       underscore,              NoSymbol,              BackSpace,               NoSymbol            ]
     };
     key <AD03> {
-        [ u,                       U,                       bracketleft,             Greek_lambda            ],
-        [ Up,               Up                        ]
+        [ u,                       U,                       bracketleft,             Greek_lambda,          Up,                      Up                  ]
     };
     key <AD04> {
-        [ y,                       Y,                       bracketright,            Greek_chi               ],
-        [ Delete,                  NoSymbol                  ]
+        [ y,                       Y,                       bracketright,            Greek_chi,             Delete,                  NoSymbol            ]
     };
     key <AD05> {
-        [ z,                       Z,                       asciicircum,             Greek_omega             ],
-        [ Next,                    NoSymbol                  ]
+        [ z,                       Z,                       asciicircum,             Greek_omega,           Next,                    NoSymbol            ]
     };
-
     key <AD06> {
-        [ x,                       X,                       exclam,                  Greek_kappa             ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ x,                       X,                       exclam,                  Greek_kappa,           NoSymbol,                NoSymbol            ]
     };
     key <AD07> {
-        [ k,                       K,                       less,                    Greek_psi               ],
-        [ 1,                       NoSymbol                  ]
+        [ k,                       K,                       less,                    Greek_psi,             1,                       NoSymbol            ]
     };
     key <AD08> {
-        [ c,                       C,                       greater,                 Greek_gamma             ],
-        [ 2,                       NoSymbol                  ]
+        [ c,                       C,                       greater,                 Greek_gamma,           2,                       NoSymbol            ]
     };
     key <AD09> {
-        [ w,                       W,                       equal,                   Greek_phi               ],
-        [ 3,                       NoSymbol                  ]
+        [ w,                       W,                       equal,                   Greek_phi,             3,                       NoSymbol            ]
     };
     key <AD10> {
-        [ b,                       B,                       ampersand,               U03D5                   ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ b,                       B,                       ampersand,               U03D5,                 NoSymbol,                NoSymbol            ]
     };
 
     key.type[Group1] = "FOUR_LEVEL";
     key <AD11> {
-        [ NoSymbol,                NoSymbol,                  NoSymbol,                   Greek_finalsmallsigma   ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ NoSymbol,                NoSymbol,                NoSymbol,                Greek_finalsmallsigma, NoSymbol,                NoSymbol            ]
     };
     key <AD12> {
-        [ NoSymbol,             NoSymbol,              NoSymbol,             NoSymbol              ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ NoSymbol,                NoSymbol,                NoSymbol,                NoSymbol,              NoSymbol,                NoSymbol            ]
     };
 
     // Middle row
@@ -137,114 +113,94 @@ xkb_symbols "basic" {
             symbols[Group2] = [ Multi_key ]
     };
 
-    key.type[Group1] = "FOUR_LEVEL_SEMIALPHABETIC";
+    key.type[Group1] = "EIGHT_LEVEL_SEMIALPHABETIC";
     key <AC01> {
-        [ o,                       O,                       slash,                   NoSymbol                ],
-        [ Home,                    NoSymbol                  ]
+        [ o,                       O,                       slash,                   NoSymbol,              Home,                    NoSymbol            ]
     };
     key <AC02> {
-        [ h,                       H,                       minus,                   Greek_iota              ],
-        [ Left,                    Left                      ]
+        [ h,                       H,                       minus,                   Greek_iota,            Left,                    Left                ]
     };
     key <AC03> {
-        [ e,                       E,                       braceleft,               Greek_alpha             ],
-        [ Down,                    Down                      ]
+        [ e,                       E,                       braceleft,               Greek_alpha,           Down,                    Down                ]
     };
     key <AC04> {
-        [ a,                       A,                       braceright,              Greek_epsilon           ],
-        [ Right,                   Right                     ]
+        [ a,                       A,                       braceright,              Greek_epsilon,         Right,                   Right               ]
     };
     key <AC05> {
-        [ i,                       I,                       asterisk,                Greek_omicron           ],
-        [ End,                     NoSymbol                  ]
+        [ i,                       I,                       asterisk,                Greek_omicron,         End,                     NoSymbol            ]
     };
-
     key <AC06> {
-        [ d,                       D,                       question,                Greek_sigma             ],
-        [ period,                  NoSymbol                  ]
+        [ d,                       D,                       question,                Greek_sigma,           period,                  NoSymbol            ]
     };
     key <AC07> {
-        [ r,                       R,                       parenleft,               Greek_nu                ],
-        [ 4,                       NoSymbol                  ]
+        [ r,                       R,                       parenleft,               Greek_nu,              4,                       NoSymbol            ]
     };
     key <AC08> {
-        [ t,                       T,                       parenright,              Greek_rho               ],
-        [ 5,                       NoSymbol                  ]
+        [ t,                       T,                       parenright,              Greek_rho,             5,                       NoSymbol            ]
     };
     key <AC09> {
-        [ n,                       N,                       apostrophe,              Greek_tau               ],
-        [ 6,                       NoSymbol                  ]
+        [ n,                       N,                       apostrophe,              Greek_tau,             6,                       NoSymbol            ]
     };
     key <AC10> {
-        [ s,                       S,                       colon,                   Greek_delta             ],
-        [ Escape,                  NoSymbol                  ]
+        [ s,                       S,                       colon,                   Greek_delta,           Escape,                  NoSymbol            ]
     };
 
     key <AC11> {
         type[Group1] = "ONE_LEVEL",
-            symbols[Group1] = [ ISO_Level3_Shift ],
-            type[Group2] = "ONE_LEVEL",
-            symbols[Group2] = [ ISO_Level3_Shift ]
+        symbols[Group1] = [ ISO_Level3_Shift ]
     };
-    modifier_map Mod5   { ISO_Level3_Shift };
 
     // Bottom row
     // --------------------------------------------------------------
-    key.type[Group1] = "FOUR_LEVEL";
+    key.type[Group1] = "EIGHT_LEVEL";
     key <AB01> {
-        [ comma,                   exclam,                  numbersign,              NoSymbol                ],
-        [ comma,                   NoSymbol                  ]
+        [ comma,                   exclam,                  numbersign,              NoSymbol,              comma,                   NoSymbol            ]
     };
-    key.type[Group1] = "FOUR_LEVEL_SEMIALPHABETIC";
+    
+    key.type[Group1] = "EIGHT_LEVEL_SEMIALPHABETIC";
     key <AB02> {
-        [ m,                       M,                       dollar,                  U03F5                   ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ m,                       M,                       dollar,                  U03F5,                 NoSymbol,                NoSymbol            ]
     };
     key <AB03> {
-        [ period,                  NoSymbol,                       bar,                     Greek_eta               ],
-        [ bracketleft,             NoSymbol                  ]
+        [ period,                  NoSymbol,                bar,                     Greek_eta,             bracketleft,             NoSymbol            ]
     };
     key <AB04> {
-        [ j,                       J,                       asciitilde,              Greek_pi                ],
-        [ bracketright,            NoSymbol                  ]
+        [ j,                       J,                       asciitilde,              Greek_pi,              bracketright,            NoSymbol            ]
     };
-    key.type[Group1] = "FOUR_LEVEL";
+    
+    key.type[Group1] = "EIGHT_LEVEL";
     key <AB05> {
-        [ semicolon,               semicolon,                   grave,                   Greek_zeta              ],
-        [ NoSymbol,                NoSymbol                  ]
+        [ semicolon,               semicolon,               grave,                   Greek_zeta,            NoSymbol,                NoSymbol            ]
     };
-    key.type[Group1] = "FOUR_LEVEL_SEMIALPHABETIC";
-
+    
+    key.type[Group1] = "EIGHT_LEVEL_SEMIALPHABETIC";
     key <AB06> {
-        [ g,                       G,                       plus,                    Greek_beta              ],
-        [ 0,                       NoSymbol                  ]
+        [ g,                       G,                       plus,                    Greek_beta,            0,                       NoSymbol            ]
     };
     key <AB07> {
-        [ l,                       L,                       percent,                 Greek_mu                ],
-        [ 7,                       NoSymbol                  ]
+        [ l,                       L,                       percent,                 Greek_mu,              7,                       NoSymbol            ]
     };
     key <AB08> {
-        [ p,                       P,                       backslash,               Greek_beta              ],
-        [ 8,                       NoSymbol                  ]
+        [ p,                       P,                       backslash,               Greek_beta,            8,                       NoSymbol            ]
     };
-    key.type[Group1] = "FOUR_LEVEL";
+
+    key.type[Group1] = "EIGHT_LEVEL";
     key <AB09> {
-        [ v,                       V,                at,                      Greek_mu                ],
-        [ 9,                       NoSymbol                  ]
+        [ v,                       V,                       at,                      Greek_mu,              9,                       NoSymbol            ]
     };
 
     key <AB10> {
         type[Group1] = "ONE_LEVEL",
-            symbols[Group1] = [ Mode_switch ],
-            type[Group2] = "ONE_LEVEL",
-            symbols[Group2] = [ Mode_switch ]
+        symbols[Group1] = [ ISO_Level5_Shift ]
     };
+    include "level5(modifier_mapping)"
 
 
     // Space key
     // --------------------------------------------------------------
+    key.type[Group1] = "EIGHT_LEVEL";
     key <SPCE> {
-        [ space,                   space,                   space,                   space            ],
-        [ space,                   space                    ]
+        //[ space,                   space,                   space,                   space,                 space,                   space               ]
+        [ space ]
     };
 };

--- a/linux/xkb/symbols/3l
+++ b/linux/xkb/symbols/3l
@@ -200,7 +200,6 @@ xkb_symbols "basic" {
     // --------------------------------------------------------------
     key.type[Group1] = "EIGHT_LEVEL";
     key <SPCE> {
-        //[ space,                   space,                   space,                   space,                 space,                   space               ]
-        [ space ]
+        [ space,                   space,                   space,                   space,                 space,                   space               ]
     };
 };

--- a/linux/xkb/symbols/3l
+++ b/linux/xkb/symbols/3l
@@ -9,7 +9,6 @@ xkb_symbols "basic" {
     // Tab as Escape
     // --------------------------------------------------------------
     key  <TAB> {
-        //[ Escape,                  Escape,                  Escape,                  Escape,                Escape,                Escape               ]
         [ Escape ]
     };
 
@@ -17,7 +16,6 @@ xkb_symbols "basic" {
     // Number row
     // --------------------------------------------------------------
     key <TLDE> {
-        //[ NoSymbol,                NoSymbol,                NoSymbol,                NoSymbol,              NoSymbol,              NoSymbol              ]
         [ NoSymbol ]
     };
 

--- a/linux/xkb/symbols/3l
+++ b/linux/xkb/symbols/3l
@@ -115,7 +115,7 @@ xkb_symbols "basic" {
 
     key.type[Group1] = "EIGHT_LEVEL_SEMIALPHABETIC";
     key <AC01> {
-        [ o,                       O,                       slash,                   NoSymbol,              Home,                    NoSymbol            ]
+        [ o,                       O,                       slash,                   NoSymbol,              Home,                    Home                ]
     };
     key <AC02> {
         [ h,                       H,                       minus,                   Greek_iota,            Left,                    Left                ]
@@ -127,7 +127,7 @@ xkb_symbols "basic" {
         [ a,                       A,                       braceright,              Greek_epsilon,         Right,                   Right               ]
     };
     key <AC05> {
-        [ i,                       I,                       asterisk,                Greek_omicron,         End,                     NoSymbol            ]
+        [ i,                       I,                       asterisk,                Greek_omicron,         End,                     End                 ]
     };
     key <AC06> {
         [ d,                       D,                       question,                Greek_sigma,           period,                  NoSymbol            ]

--- a/linux/xkb/symbols/3l
+++ b/linux/xkb/symbols/3l
@@ -65,7 +65,7 @@ xkb_symbols "basic" {
     // Top row
     // --------------------------------------------------------------
     key.type[Group1] = "EIGHT_LEVEL_SEMIALPHABETIC";
-    key <AD01> { 
+    key <AD01> {
         [ q,                       Q,                       quotedbl,                Greek_xi,              Prior,                   NoSymbol            ]
     };
     key <AD02> {
@@ -156,7 +156,7 @@ xkb_symbols "basic" {
     key <AB01> {
         [ comma,                   exclam,                  numbersign,              NoSymbol,              comma,                   NoSymbol            ]
     };
-    
+
     key.type[Group1] = "EIGHT_LEVEL_SEMIALPHABETIC";
     key <AB02> {
         [ m,                       M,                       dollar,                  U03F5,                 NoSymbol,                NoSymbol            ]
@@ -167,12 +167,12 @@ xkb_symbols "basic" {
     key <AB04> {
         [ j,                       J,                       asciitilde,              Greek_pi,              bracketright,            NoSymbol            ]
     };
-    
+
     key.type[Group1] = "EIGHT_LEVEL";
     key <AB05> {
         [ semicolon,               semicolon,               grave,                   Greek_zeta,            NoSymbol,                NoSymbol            ]
     };
-    
+
     key.type[Group1] = "EIGHT_LEVEL_SEMIALPHABETIC";
     key <AB06> {
         [ g,                       G,                       plus,                    Greek_beta,            0,                       NoSymbol            ]


### PR DESCRIPTION
Changed how the layers modifiers are implemented to improve support. Based on my testing this should be functionally equivalent to the old implementation.