### PR TITLE
Add a 3l variant for emacs users

### DIFF
--- a/linux/xkb/symbols/3l
+++ b/linux/xkb/symbols/3l
@@ -83,7 +83,7 @@ xkb_symbols "cros" {
 // tab back to tab.
 partial modifier_keys
 xkb_symbols "3l-emacs" {
-    include "us(3l)"
+    include "3l(basic)"
     name[Group1] = "English (3l, emacs)";
 
     key <TAB> { [ Tab ] };

--- a/linux/xkb/symbols/3l
+++ b/linux/xkb/symbols/3l
@@ -78,3 +78,16 @@ xkb_symbols "cros" {
         symbols[Group1] = [ Tab ]
     };
 };
+
+// A variant for emacs users, which maps control to caps lock and (re)maps 
+// tab back to tab.
+partial modifier_keys
+xkb_symbols "3l-emacs" {
+    include "us(3l)"
+    name[Group1] = "English (3l, emacs)";
+
+    key <TAB> { [ Tab ] };
+    key <CAPS> { [ Control_L ] };
+
+    modifier_map Control { <CAPS> };
+};


### PR DESCRIPTION
Add a new 3l variant which makes the control key more convenient.

Unfortunately, I haven't touched Windows, MacOS, or FreeBSD. I don't have a way to test on MacOS or (easily FreeBSD). I may try my hand at the AHK script in the somewhat near future since I boot into windows fairly regularly.

