### PR TITLE
Restore unused keys from qwerty

### DIFF
--- a/linux/xkb/symbols/3l
+++ b/linux/xkb/symbols/3l
@@ -11,16 +11,20 @@ xkb_symbols "basic" {
     key <AB10> { [ ISO_Level5_Shift ] }; // Cur/Num Modifier
 
     // Top row numbers - not part of spec, but given for convenience
-    key <AE01> { [ 1 ] };
-    key <AE02> { [ 2 ] };
-    key <AE03> { [ 3 ] };
-    key <AE04> { [ 4 ] };
-    key <AE05> { [ 5 ] };
-    key <AE06> { [ 6 ] };
-    key <AE07> { [ 7 ] };
-    key <AE08> { [ 8 ] };
-    key <AE09> { [ 9 ] };
-    key <AE10> { [ 0 ] };
+    key.type[Group1] = "TWO_LEVEL";
+    key <TLDE> { [ grave, asciitilde  ] };
+    key <AE01> { [ 1,     exclam      ] };
+    key <AE02> { [ 2,     at          ] };
+    key <AE03> { [ 3,     numbersign  ] };
+    key <AE04> { [ 4,     dollar      ] };
+    key <AE05> { [ 5,     percent     ] };
+    key <AE06> { [ 6,     asciicircum ] };
+    key <AE07> { [ 7,     ampersand   ] };
+    key <AE08> { [ 8,     asterisk    ] };
+    key <AE09> { [ 9,     parenleft   ] };
+    key <AE10> { [ 0,     parenright  ] };
+    key <AE11> { [ minus, underscore  ] };
+    key <AE12> { [ equal, plus        ] };
 
     // Main keys
     // Order of mods (defined by EIGHT_LEVEL_SEMIALPHABETIC) is:
@@ -28,17 +32,19 @@ xkb_symbols "basic" {
     key.type[Group1] = "EIGHT_LEVEL_SEMIALPHABETIC";
 
     // Second row
-    key <AD01> { [ q,         Q,         quotedbl,     Greek_omicron,  Prior,     Prior,      U21CD,    Greek_OMICRON ] };
-    key <AD02> { [ f,         F,         underscore,   Greek_phi,      BackSpace, BackSpace,  U21A4,    Greek_PHI ] };
-    key <AD03> { [ u,         U,         bracketleft,  Greek_upsilon,  Up,        Up,         U2191,    Greek_UPSILON ] };
-    key <AD04> { [ y,         Y,         bracketright, Greek_psi,      Delete,    Delete,     U21A6,    Greek_PSI ] };
-    key <AD05> { [ z,         Z,         asciicircum,  Greek_zeta,     Next,      Next,       U21CF,    Greek_ZETA ] };
-    key <AD06> { [ x,         X,         exclam,       Greek_xi,       NoSymbol,  NoSymbol,   U2260,    Greek_XI ] };
-    key <AD07> { [ k,         K,         less,         Greek_kappa,    1,         A,          U2264,    Greek_KAPPA ] };
-    key <AD08> { [ c,         C,         greater,      Greek_chi,      2,         B,          U2265,    Greek_CHI ] };
-    key <AD09> { [ w,         W,         equal,        Greek_omega,    3,         C,          U2261,    Greek_OMEGA ] };
-    key <AD10> { [ b,         B,         ampersand,    Greek_beta,     NoSymbol,  NoSymbol,   U2248,    Greek_BETA ] };
-
+    key <AD01> { [ q,            Q,          quotedbl,     Greek_omicron,  Prior,     Prior,      U21CD,    Greek_OMICRON ] };
+    key <AD02> { [ f,            F,          underscore,   Greek_phi,      BackSpace, BackSpace,  U21A4,    Greek_PHI ] };
+    key <AD03> { [ u,            U,          bracketleft,  Greek_upsilon,  Up,        Up,         U2191,    Greek_UPSILON ] };
+    key <AD04> { [ y,            Y,          bracketright, Greek_psi,      Delete,    Delete,     U21A6,    Greek_PSI ] };
+    key <AD05> { [ z,            Z,          asciicircum,  Greek_zeta,     Next,      Next,       U21CF,    Greek_ZETA ] };
+    key <AD06> { [ x,            X,          exclam,       Greek_xi,       NoSymbol,  NoSymbol,   U2260,    Greek_XI ] };
+    key <AD07> { [ k,            K,          less,         Greek_kappa,    1,         A,          U2264,    Greek_KAPPA ] };
+    key <AD08> { [ c,            C,          greater,      Greek_chi,      2,         B,          U2265,    Greek_CHI ] };
+    key <AD09> { [ w,            W,          equal,        Greek_omega,    3,         C,          U2261,    Greek_OMEGA ] };
+    key <AD10> { [ b,            B,          ampersand,    Greek_beta,     NoSymbol,  NoSymbol,   U2248,    Greek_BETA ] };
+    key <AD11> { [ bracketleft,  braceleft,  NoSymbol,     NoSymbol,       NoSymbol,  NoSymbol,   NoSymbol, NoSymbol ] };
+    key <AD12> { [ bracketright, braceright, NoSymbol,     NoSymbol,       NoSymbol,  NoSymbol,   NoSymbol, NoSymbol ] };
+    
     // Home row
     key <AC01> { [ o,         O,         slash,        Greek_omega,    Home,      Home,       U21D0,    Greek_OMEGA ] };
     key <AC02> { [ h,         H,         minus,        Greek_theta,    Left,      Left,       U2190,    Greek_THETA ] };


### PR DESCRIPTION
This patch adds the symbols on the top row in qwerty accessed via shift, as well as the square bracket keys above enter.
Occasionally I find it convenient to have these keys in addition to the regular symbols layer. Typing some symbols with one hand (like # and $) is a real stretch on l3 but easy on qwerty. If I am reviewing a document and just making minor corrections, I sometime prefer to keep one hand on the mouse and use the other to type, which is when I like to use the qwerty symbols.
Since these keys aren't used for anything in 3l, this seems like a low impact addition that someone might find useful.