### PR TITLE
Update to AHK v2.0 syntax

### DIFF
--- a/windows/ahk/3l.ahk
+++ b/windows/ahk/3l.ahk
@@ -1,181 +1,205 @@
-#Persistent
-#MaxHotkeysPerInterval 999999999
+Persistent
+A_MaxHotkeysPerInterval := 999999999
 +SC029::CapsLock
 
 SC00F::Escape
 SC010::q
 +SC010::Q
-SC028 & SC010::Send {"}
-SC035 & SC010::Send {PgUp}
+SC028 & SC010::Send("{`"}")
+SC035 & SC010::Send("{PgUp}")
 SC011::f
 +SC011::F
-SC028 & SC011::Send {_}
+SC028 & SC011::Send("{_}")
 SC035 & SC011::
+{ 
+global 
     if (GetKeyState("CTRL"))  {
-        Send ^{Backspace}
+        Send("^{Backspace}")
     } else {
-        Send {Backspace}
+        Send("{Backspace}")
     }
 return
+} 
 SC012::u
 +SC012::U
-SC028 & SC012::Send {[}
+SC028 & SC012::Send("{[}")
 SC035 & SC012::
+{ 
+global 
     if (GetKeyState("CTRL") && !GetKeyState("SHIFT"))  {
-        Send ^{Up}
+        Send("^{Up}")
     } else if (!GetKeyState("CTRL") && GetKeyState("SHIFT"))  {
-        Send +{Up}
+        Send("+{Up}")
     } else if (GetKeyState("CTRL") && GetKeyState("SHIFT"))  {
-        Send ^+{Up}
+        Send("^+{Up}")
     } else {
-        Send {Up}
+        Send("{Up}")
     }
 return
+} 
 SC013::y
 +SC013::Y
-SC028 & SC013::Send {]}
+SC028 & SC013::Send("{]}")
 SC035 & SC013::
+{ 
+global 
     if (GetKeyState("CTRL"))  {
-        Send ^{Delete}
+        Send("^{Delete}")
     } else {
-        Send {Delete}
+        Send("{Delete}")
     }
 return
+} 
 SC014::z
 +SC014::Z
-SC028 & SC014::Send {^}
-SC035 & SC014::Send {PgDn}
+SC028 & SC014::Send("{^}")
+SC035 & SC014::Send("{PgDn}")
 SC015::x
 +SC015::X
-SC028 & SC015::Send {!}
+SC028 & SC015::Send("{!}")
 SC016::k
 +SC016::K
-SC028 & SC016::Send {<}
-SC035 & SC016::Send {1}
+SC028 & SC016::Send("{<}")
+SC035 & SC016::Send("{1}")
 SC017::c
 +SC017::C
-SC028 & SC017::Send {>}
-SC035 & SC017::Send {2}
+SC028 & SC017::Send("{>}")
+SC035 & SC017::Send("{2}")
 SC018::w
 +SC018::W
-SC028 & SC018::Send {=}
-SC035 & SC018::Send {3}
+SC028 & SC018::Send("{=}")
+SC035 & SC018::Send("{3}")
 SC019::b
 +SC019::B
-SC028 & SC019::Send {&}
+SC028 & SC019::Send("{&}")
 
 SC03A::Tab
 SC01E::o
 +SC01E::O
 SC035 & SC01E::
+{ 
+global 
     if (GetKeyState("SHIFT"))  {
-        Send +{Home}
+        Send("+{Home}")
     } else {
-        Send {Home}
+        Send("{Home}")
     }
 return
-SC028 & SC01E::Send {/}
+} 
+SC028 & SC01E::Send("{/}")
 SC01F::h
 +SC01F::H
-SC028 & SC01F::Send {-}
+SC028 & SC01F::Send("{-}")
 SC035 & SC01F::
+{ 
+global 
     if (GetKeyState("CTRL") && !GetKeyState("SHIFT"))  {
-        Send ^{Left}
+        Send("^{Left}")
     } else if (!GetKeyState("CTRL") && GetKeyState("SHIFT"))  {
-        Send +{Left}
+        Send("+{Left}")
     } else if (GetKeyState("CTRL") && GetKeyState("SHIFT"))  {
-        Send ^+{Left}
+        Send("^+{Left}")
     } else {
-        Send {Left}
+        Send("{Left}")
     }
 return
+} 
 SC020::e
 +SC020::E
-SC028 & SC020::Send {{}
+SC028 & SC020::Send("{{}")
 SC035 & SC020::
+{ 
+global 
     if (GetKeyState("CTRL") && !GetKeyState("SHIFT"))  {
-        Send ^{Down}
+        Send("^{Down}")
     } else if (!GetKeyState("CTRL") && GetKeyState("SHIFT"))  {
-        Send +{Down}
+        Send("+{Down}")
     } else if (GetKeyState("CTRL") && GetKeyState("SHIFT"))  {
-        Send ^+{Down}
+        Send("^+{Down}")
     } else {
-        Send {Down}
+        Send("{Down}")
     }
 return
+} 
 SC021::a
 +SC021::A
-SC028 & SC021::Send {}}
+SC028 & SC021::Send("{}}")
 SC035 & SC021::
+{ 
+global 
     if (GetKeyState("CTRL") && !GetKeyState("SHIFT"))  {
-        Send ^{Right}
+        Send("^{Right}")
     } else if (!GetKeyState("CTRL") && GetKeyState("SHIFT"))  {
-        Send +{Right}
+        Send("+{Right}")
     } else if (GetKeyState("CTRL") && GetKeyState("SHIFT"))  {
-        Send ^+{Right}
+        Send("^+{Right}")
     } else {
-        Send {Right}
+        Send("{Right}")
     }
 return
+} 
 SC022::i
 +SC022::I
-SC028 & SC022::Send {*}
+SC028 & SC022::Send("{*}")
 SC035 & SC022::
+{ 
+global 
     if (GetKeyState("SHIFT"))  {
-        Send +{End}
+        Send("+{End}")
     } else {
-        Send {End}
+        Send("{End}")
     }
 return
+} 
 SC023::d
 +SC023::D
-SC028 & SC023::Send {?}
-SC035 & SC023::Send {.}
+SC028 & SC023::Send("{?}")
+SC035 & SC023::Send("{.}")
 SC024::r
 +SC024::R
-SC028 & SC024::Send {(}
-SC035 & SC024::Send {4}
+SC028 & SC024::Send("{(}")
+SC035 & SC024::Send("{4}")
 SC025::t
 +SC025::T
-SC028 & SC025::Send {)}
-SC035 & SC025::Send {5}
+SC028 & SC025::Send("{)}")
+SC035 & SC025::Send("{5}")
 SC026::n
 +SC026::N
-SC028 & SC026::Send {'}
-SC035 & SC026::Send {6}
+SC028 & SC026::Send("{'}")
+SC035 & SC026::Send("{6}")
 SC027::s
 +SC027::S
-SC028 & SC027::Send {:}
+SC028 & SC027::Send("{:}")
 
-SC02C::Send {,}
-SC028 & SC02C::Send {#}
+SC02C::Send("{,}")
+SC028 & SC02C::Send("{#}")
 SC02D::m
 +SC02D::M
-SC028 & SC02D::Send {$}
-SC02E::Send {.}
-+SC02E::Send {.}
-SC028 & SC02E::Send {|}
+SC028 & SC02D::Send("{$}")
+SC02E::Send("{.}")
++SC02E::Send("{.}")
+SC028 & SC02E::Send("{|}")
 SC02F::j
 +SC02F::J
-SC028 & SC02F::Send {~}
-SC030::Send {;}
-SC028 & SC030::Send {``}
+SC028 & SC02F::Send("{~}")
+SC030::Send("{;}")
+SC028 & SC030::Send("{``}")
 SC031::g
 +SC031::G
-SC028 & SC031::Send {+}
-SC035 & SC031::Send {0}
+SC028 & SC031::Send("{+}")
+SC035 & SC031::Send("{0}")
 SC032::l
 +SC032::L
-SC028 & SC032::Send {`%}
-SC035 & SC032::Send {7}
+SC028 & SC032::Send("{`%}")
+SC035 & SC032::Send("{7}")
 SC033::p
 +SC033::P
-SC028 & SC033::Send {\}
-SC035 & SC033::Send {8}
+SC028 & SC033::Send("{\}")
+SC035 & SC033::Send("{8}")
 SC034::v
 +SC034::V
-SC028 & SC034::Send {@}
-SC035 & SC034::Send {9}
+SC028 & SC034::Send("{@}")
+SC035 & SC034::Send("{9}")
 
-RAlt & LAlt::Suspend
-LAlt & RAlt::Suspend
+RAlt & LAlt::Suspend()
+LAlt & RAlt::Suspend()


### PR DESCRIPTION
AHK v2.0 changes some syntax slightly. See https://www.autohotkey.com/docs/v2/v2-changes.htm. It doesn't seem like they are in a hurry to drop v1, but it is deprecated. v2 has been around since 2016, so its probably safe to update.